### PR TITLE
package追加した際のための対応

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,5 +7,3 @@ RUN apt update && apt upgrade
 RUN yarn global add expo-cli
 
 RUN yarn global add ngrok
-
-RUN yarn

--- a/frontend/doradora/package.json
+++ b/frontend/doradora/package.json
@@ -1,7 +1,7 @@
 {
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
-    "start": "expo start",
+    "start": "yarn && expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",


### PR DESCRIPTION
他人がパッケージ追加しても反映できない状態だったので
* DockerFileの最終行は意味が無かったので削除
* `yarn start` する前にパッケージの確認するように変更
  * パッケージが既にあればインストールしないので時間がかかるのは初回のみ